### PR TITLE
Update graviton.guard

### DIFF
--- a/rules/graviton.guard
+++ b/rules/graviton.guard
@@ -4,7 +4,7 @@
 # that are more power-efficient.
 
 let rds_db = Resources.*[Type == 'AWS::RDS::DBInstance']
- let valid_instance_classes = ['db.m6g', 'db.m6gd', 'db.x2g', 'db.r6g', 'db.r6gd', 'db.t4g']
+ let valid_instance_classes = ['db.m6g', 'db.m6gd', 'db.m7g', 'db.x2g', 'db.r6g', 'db.r7g', 'db.r6gd', 'db.t4g']
 
 
 rule check_graviton_instance_usage_in_rds when %rds_db !empty {

--- a/rules/test_cases/graviton_tests.yaml
+++ b/rules/test_cases/graviton_tests.yaml
@@ -3,7 +3,7 @@
   input: {}
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: SKIP
 
 - name: TestEmptyResources
@@ -11,7 +11,7 @@
      Resources: {}
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: SKIP
 
 - name: TestRDSWithGraviton
@@ -30,7 +30,7 @@
           DBParameterGroupName: 'MyRDSParamGroup'
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: PASS
+      check_graviton_instance_usage_in_rds: PASS
       check_graviton_architecture_usage_in_lambda: SKIP
 
 - name: TestRDSWithoutGraviton
@@ -49,7 +49,7 @@
           DBParameterGroupName: 'MyRDSParamGroup'
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: FAIL
+      check_graviton_instance_usage_in_rds: FAIL
       check_graviton_architecture_usage_in_lambda: SKIP
 
 - name: TestLambdaWithZipAndWithoutGraviton
@@ -73,7 +73,7 @@
           PackageType: 'Zip'
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: FAIL
 
 - name: TestLambdaWithZipAndWithGraviton
@@ -97,7 +97,7 @@
           PackageType: 'Zip' 
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: PASS
 
 - name: TestLambdaWithImageAndWithGraviton
@@ -121,7 +121,7 @@
           PackageType: 'Image' 
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: PASS
 
 - name: TestLambdaWithImageAndWithoutGraviton
@@ -145,7 +145,7 @@
           PackageType: 'Image'
   expectations:
     rules:
-      check_graviton_instace_usage_in_rds: SKIP
+      check_graviton_instance_usage_in_rds: SKIP
       check_graviton_architecture_usage_in_lambda: FAIL
 
       


### PR DESCRIPTION
New gravition instance types https://aws.amazon.com/about-aws/whats-new/2023/04/amazon-rds-m7g-r7g-database-instances/

*Issue #, if available:*

*Description of changes:*
Added m7g and r7g as valid instance types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
