### PR TITLE
Fixed edge case when comparing boolean types with strings

### DIFF
--- a/susscanner/rules/cloud_front.guard
+++ b/susscanner/rules/cloud_front.guard
@@ -13,7 +13,7 @@ let cf_def_ttl_policies = Resources.*[
 rule ensure_default_compression_on when %cf !empty {
     let compression = %cf.Properties.DistributionConfig.DefaultCacheBehavior.Compress
     %compression exists
-    %compression == true
+    %compression in ['true', true]
 }
 
 rule ensure_compression_on when %cf !empty {
@@ -22,7 +22,7 @@ rule ensure_compression_on when %cf !empty {
             when CacheBehaviors exists {
                 CacheBehaviors[*] {
                     Compress exists
-                    Compress == true
+                    Compress in ['true', true]
                 }
             }
         }

--- a/susscanner/rules/rds.guard
+++ b/susscanner/rules/rds.guard
@@ -10,6 +10,6 @@ let rds_db = Resources.*[Type == 'AWS::RDS::DBInstance']
 rule check_rds_performanceinsights_enabled when %rds_db !empty {
     %rds_db.Properties.EnablePerformanceInsights exists
     when %rds_db.Properties.EnablePerformanceInsights exists {
-        %rds_db.Properties.EnablePerformanceInsights == 'true'
+        %rds_db.Properties.EnablePerformanceInsights in ['true', true]
     }
 }

--- a/susscanner/rules/test_cases/cloud_front_tests.yaml
+++ b/susscanner/rules/test_cases/cloud_front_tests.yaml
@@ -19,7 +19,7 @@
         Properties:
           DistributionConfig: 
             DefaultCacheBehavior:
-              Compress: false
+              Compress: "false"
   expectations:
     rules:
       ensure_default_compression_on: FAIL
@@ -80,7 +80,7 @@
               - PathPattern: pattern/1
                 Compress: true
               - PathPattern: pattern/2
-                Compress: true
+                Compress: "true"
   expectations:
     rules:
       ensure_compression_on: PASS

--- a/susscanner/rules/test_cases/rds_tests.yaml
+++ b/susscanner/rules/test_cases/rds_tests.yaml
@@ -31,6 +31,25 @@
     rules:
       check_rds_performanceinsights_enabled: PASS
 
+- name: TestRDSWithPerfInsightsBoolean
+  input:
+    Resources:
+      RDSInstance:
+        Type: AWS::RDS::DBInstance
+        Properties:
+          DBName: 'DBName'
+          AllocatedStorage: '5'
+          DBInstanceClass: db.m6g
+          Engine: MySQL
+          EngineVersion: 5.6.19
+          MasterUsername: 'DBUser'
+          MasterUserPassword: 'DBPassword'
+          DBParameterGroupName: 'MyRDSParamGroup'
+          EnablePerformanceInsights: true
+  expectations:
+    rules:
+      check_rds_performanceinsights_enabled: PASS
+
 - name: TestRDSWithoutPerfInsights
   input:
     Resources:

--- a/tests/test-data/rds-output.txt
+++ b/tests/test-data/rds-output.txt
@@ -1,0 +1,157 @@
+{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "rest_api_compression_max",
+    "rest_api_compression_min",
+    "rest_api_compression_exists"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "ensure_compression_on",
+    "ensure_default_compression_on",
+    "check_default_ttl",
+    "check_max_ttl"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "ensure_all_loggroups_have_retention"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "check_codeguru_association"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "from_port_is_ssh",
+    "to_port_is_ssh",
+    "port_range_includes_ssh"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "emr_target_spot_config_configured",
+    "emr_use_spot"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "check_glue_job_allocatedcapacity",
+    "check_glue_job_timeout",
+    "check_glue_job_workernodes",
+    "check_glue_job_maxcapacity"
+  ],
+  "compliant": []
+}RDS_with_DBParameterGroup.yaml Status = FAIL
+FAILED rules
+graviton.guard/check_graviton_instance_usage_in_rds           FAIL
+---
+{
+  "name": "",
+  "metadata": {},
+  "status": "FAIL",
+  "not_compliant": [
+    {
+      "Rule": {
+        "name": "check_graviton_instance_usage_in_rds",
+        "metadata": {},
+        "messages": {
+          "custom_message": null,
+          "error_message": null
+        },
+        "checks": [
+          {
+            "Clause": {
+              "Binary": {
+                "context": " %rds_db[*].Properties.DBInstanceClass IN  %valid_instance_classes",
+                "messages": {
+                  "custom_message": null,
+                  "error_message": "Check was not compliant as property [/Resources/MyDB/Properties/DBInstanceClass[L:40,C:23]] was not present in [(resolved, Path=[L:0,C:0] Value=[\"db.m6g\",\"db.m6gd\",\"db.m7g\",\"db.x2g\",\"db.r6g\",\"db.r7g\",\"db.r6gd\",\"db.t4g\"])]"
+                },
+                "check": {
+                  "InResolved": {
+                    "from": {
+                      "path": "/Resources/MyDB/Properties/DBInstanceClass",
+                      "value": "db.t2.small"
+                    },
+                    "to": [
+                      {
+                        "path": "",
+                        "value": [
+                          "db.m6g",
+                          "db.m6gd",
+                          "db.m7g",
+                          "db.x2g",
+                          "db.r6g",
+                          "db.r7g",
+                          "db.r6gd",
+                          "db.t4g"
+                        ]
+                      }
+                    ],
+                    "comparison": [
+                      "In",
+                      false
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "not_applicable": [
+    "check_graviton_architecture_usage_in_lambda"
+  ],
+  "compliant": []
+}{
+  "name": "",
+  "metadata": {},
+  "status": "PASS",
+  "not_compliant": [],
+  "not_applicable": [],
+  "compliant": [
+    "check_rds_performanceinsights_enabled"
+  ]
+}{
+  "name": "",
+  "metadata": {},
+  "status": "SKIP",
+  "not_compliant": [],
+  "not_applicable": [
+    "ensure_all_buckets_have_lifecycle_configuration"
+  ],
+  "compliant": []
+}

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -63,6 +63,5 @@ class TestScan(unittest.TestCase):
         self.assertEqual(fr[0]["rule_name"], "check_graviton_instance_usage_in_rds")
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -51,6 +51,18 @@ class TestScan(unittest.TestCase):
         self.assertEqual(fr[0]['rule_name'], 'check_graviton_instance_usage_in_rds')
         self.assertEqual(fr[1]['rule_name'], 'check_rds_performanceinsights_enabled')
 
+    def test_rds_output(self):
+        # Template source for this output is
+        # https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/RDS/RDS_with_DBParameterGroup.yaml
+        # with one modification - Added `EnablePerformanceInsights: 'true'`
+        with open(TEST_DATA_DIR + "rds-output.txt") as f:
+            data = f.read()
+        result = Scan.parse_cfn_guard_output(Scan(), data)
+        fr = result["failed_rules"]
+        self.assertEqual(1, len(fr))
+        self.assertEqual(fr[0]["rule_name"], "check_graviton_instance_usage_in_rds")
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed edge case when comparing boolean types with strings

Changed ` == true` to ` in ['true', true]` to allow both usage of true and 'true' in CloudFormation templates

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
